### PR TITLE
feat(group): 新增「反例（不要做）」节补齐反模式清单

### DIFF
--- a/skills/zsxq-group/SKILL.md
+++ b/skills/zsxq-group/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zsxq-group
-version: 1.3.1
+version: 1.3.2
 description: "知识星球（星球）管理：列出星球、浏览主题、查询标签、搜索成员。当用户需要查看自己加入或创建的星球、浏览星球内容、获取 group_id、查询星球标签或成员时使用。"
 metadata:
   requires:
@@ -50,3 +50,13 @@ Shortcut 未覆盖的高级操作：
 | `search_groups` | `keyword` | 按关键词搜索星球 |
 | `search_group_members` | `group_id`, `keyword`, `limit` | 搜索星球成员 |
 | `get_hashtag_topics` | `hashtag_id`, `limit`, `end_time` | 列出某标签下的主题（分页） |
+
+## 反例（不要做）
+
+| ❌ 不要做 | ✅ 应该做 |
+|----------|----------|
+| 按关键词找内容时用 `+topics` 翻页逐条人工筛选 | 用 [zsxq-topic](../zsxq-topic/SKILL.md) 的 `+search` 全文搜索 |
+| 查「自己最近发过什么」时逐个星球跑 `+topics` | 用 [zsxq-user](../zsxq-user/SKILL.md) 的 `+footprints` 一次拿到跨星球足迹 |
+| 用户只给星球名称时，让用户自己提供 group_id 或凭记忆猜 ID | 先 `group +list`（自己加入的）或 `search_groups`（公开搜索）查到 ID 再继续 |
+| 名称命中多个相似星球时默认取第一个 | 列出候选（group_id + 名称）让用户确认 |
+| 把 `search_group_members` 当成员列表接口、调大 `limit` 遍历全员 | 它是关键词搜索，只用于按昵称定位具体成员 |


### PR DESCRIPTION
## 背景

用 [darwin-skill](https://github.com/alchaincyf/darwin-skill)（9 维 rubric + 独立 judge 盲评 + 子 agent 实测）对 `skills/` 下 5 个 skill 做了基线评估。`zsxq-group` 得分最低（77.9/100），短板集中在 dim9「反例与黑名单」（4/10）—— 全文只有「应该做 X」，没有「不要做 Y」。

## 改动

`skills/zsxq-group/SKILL.md`：
- 新增「反例（不要做）」节，5 行 ❌/✅ 对照表，编码常见误用：
  - 关键词找内容误用 `+topics` 翻页（应走 `topic +search`）
  - 查自己足迹逐星球遍历（应走 `user +footprints`）
  - 让用户自己提供 group_id / 凭记忆猜 ID
  - 同名星球多候选时默认取第一个
  - 把 `search_group_members` 当全员列表接口
- 版本号 1.3.1 → 1.3.2

## 验证

- **2 个独立 judge 盲评**：dim9 4.0 → 7.75（均值），一致认可反例表覆盖关键误用场景
- **子 agent 实测（full_test）**：
  - 回归测试（星球名称→主题列表）行为无退化
  - 新增路由测试：问「我最近在各星球发过什么」，agent 明确引用反例表、正确路由到 `user +footprints` 而非遍历 `+topics` —— 改动有直接可观测的行为收益
- 综合评分 77.9 → **81.2**（+3.3）
- 体积 3187B（原文件约 128%），符合精简约定

## 备注

本次仅 bump zsxq-group 至 1.3.2，其余 4 个 skill 仍为 1.3.1；按 CLAUDE.md「版本统一」约定，可在下一轮跨 skill 改动时一起对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)